### PR TITLE
Added Two meta tags to fix error in console and two media queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 
 <head>
+   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+   <meta content="utf-8" http-equiv="encoding">
    <meta name="Association Rules mining and visualization"
       content="Better understand your bank bill, or your shopping list! No upload to a remote server is necessary! This is based on Association rules mining algorithm.">
    <title id="title">Local association learning in JS</title>

--- a/style/main.css
+++ b/style/main.css
@@ -297,3 +297,52 @@ h2 {
   line-height: 32px;
   margin: 0 0 24px;
 }
+
+/* centered download rules and upload,
+  small change to myBar */
+@media only screen and (max-width: 768px) {
+  #h1 
+  {
+    text-align: center;
+  }
+
+  .csv-file
+  {
+    margin-left: -40px;
+  }
+
+  .input_container
+  {
+    justify-content: space-evenly;
+  }
+}
+
+/* centered download rules and upload, 
+  also Some smaller fonts to fit everything better, 
+  small change to myBar */
+@media only screen and (max-width: 320px) {
+  #h1 
+  {
+    font-size: 2rem;
+  }
+
+  .csv-file
+  {
+    font-size: 18px;
+    text-align: center;
+    margin-left: 0px;
+    margin-right: 10px;
+    
+  }
+
+  .choose-file
+  {
+    padding-top: 20px;
+  }
+
+  #myBar
+  {
+    width: 5%;
+    padding-left: 2px;
+  }
+}


### PR DESCRIPTION
Added <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
<meta content="utf-8" http-equiv="encoding"> to start of head tag. This stops the following error;
"The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol." coming up in the console.

Added two media queries for two separate max-widths.